### PR TITLE
Add additional Git/GitHub class link

### DIFF
--- a/content/resources.md
+++ b/content/resources.md
@@ -24,6 +24,7 @@ weight: 20
 # Git and GitHub References
   * [Git cheat sheet](https://services.github.com/on-demand/downloads/github-git-cheat-sheet/) ([PDF](https://services.github.com/on-demand/downloads/github-git-cheat-sheet.pdf))
   * [Intro to Git on Codecademy](https://www.codecademy.com/learn/learn-git)
+  * [Udacity Free Course: How to use Git and GitHub](https://in.udacity.com/course/how-to-use-git-and-github--ud775-india)
   * [Atlassian Git tutorials](https://www.atlassian.com/git/tutorials)
   * [GitHub workflow documentation](https://help.github.com/categories/collaborating-with-issues-and-pull-requests/)
   * [O'Reilly Git Pocket Guide](http://shop.oreilly.com/product/0636920024972.do) ([Amazon](https://www.amazon.com/Git-Pocket-Guide-Working-Introduction/dp/1449325866/))


### PR DESCRIPTION
Added the Git/GitHub Udacity free online class that taught me Git/GitHub. 
Looked good locally: 

![image](https://user-images.githubusercontent.com/33295910/51077597-b838a380-165d-11e9-96b4-5fae419d1f3b.png)
