### PR TITLE
Fixed markdown newline, removed <br> tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ Make your edits & when finished:
 
 * commit your changes locally... you made a branch, right? ;-)
 * push to your fork on GitHub
-* open a [pull request][github_pr]<br/>_A preview of the site will be linked from the pull request ticket_
+* open a [pull request][github_pr]  
+  _A preview of the site will be linked from the pull request ticket_
 * notify someone in Slack to review the change and merge the pull request
 
 ## A Note on Front Matter and Drafts

--- a/content/post/how-to-read-in-file-content.md
+++ b/content/post/how-to-read-in-file-content.md
@@ -21,7 +21,7 @@ The sample file referenced in this post is available for download to follow alon
 
 The standard steps for reading a file are:
 
-  1. Open the file using the function `open()`.  This returns a _**fileobject**_ for interaction.<br>
+  1. Open the file using the function `open()`.  This returns a _**fileobject**_ for interaction.  
     The documentation for `open` is available [here][open_docs].
   2. Read data from the fileobject using one of the methods described in the next section.
   3. Close the fileobject.  You can do this explicitly by calling the method `fileobject.close()` or handle it automatically through the use of a `with` block.

--- a/content/start.md
+++ b/content/start.md
@@ -13,9 +13,9 @@ weight: 10
 There are a few steps you will need to take in order to participate with the group:
 
   1. If you haven't already done so, sign up with our {{< meetuplink "Meetup group" >}}
-  2. Join our Slack group: {{< slackjoinrequest >}} <br/>
+  2. Join our Slack group: {{< slackjoinrequest >}}  
     _Note: the auto-invitation can be flaky; if the above doesn't work you can ask any member to send you an invitation at the next Meetup._
-  3. Sign up for an account on [Edx.org](https://edx.org/). <br/>
+  3. Sign up for an account on [Edx.org](https://edx.org/).  
     You can also register for the current course: {{< courselink >}}
   4. **Optional:** Sign up for an account on [GitHub](https://www.github.com).
 


### PR DESCRIPTION
Now correctly using 2-trailing spaces in markdown to mark a hard
newline instead of incorrectly including a `<br>` HTML tag