### PR TITLE
Add Podcast.__init__ podcast

### DIFF
--- a/content/resources.md
+++ b/content/resources.md
@@ -58,6 +58,7 @@ weight: 20
   * [Talk Python To Me](https://talkpython.fm/) "Broadcast" locally from Portland!
   * [Python Bytes](https://pythonbytes.fm/) A weekly review of Python headlines  (also local!)
   * [Test and Code](https://testandcode.com/) A Python podcast with a focus on testing (yups, also local!)
+  * [Podcast.\_\_init\_\_](https://www.podcastinit.com/) A weekly podcast about Python and the people who make it great.
 
 # Code Challenge Sites
   * [CodingBat](https://codingbat.com/python)


### PR DESCRIPTION
Add the 'Podcast.__init__' podcast to the podcasts section on the resources page.

Looks good in local:

![image](https://user-images.githubusercontent.com/33295910/51287490-8cdeed00-19ac-11e9-8e40-304f2f873797.png)
