### PR TITLE
Use 'now' timestamp for updated date in footer

### DIFF
--- a/layouts/_default/index.rss.xml
+++ b/layouts/_default/index.rss.xml
@@ -8,7 +8,7 @@
     <managingEditor>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Author.email }}
     <webMaster>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}
     <copyright>{{.}}</copyright>{{end}}{{ if not .Date.IsZero }}
-    <lastBuildDate>{{ .Site.LastChange.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
+    <lastBuildDate>{{ now.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
     {{ with .OutputFormats.Get "RSS" }}
         {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
     {{ end }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -11,7 +11,7 @@
     </div>
     <div class="content has-text-centered has-text-grey-light is-size-7">
         <p>
-            <em>site updated {{ .Site.LastChange.Format "2006-01-02 15:04" }}</em>
+            <em>site updated {{ now.Format "2006-01-02 15:04" }}</em>
         </p>
     </div>
 </footer>


### PR DESCRIPTION
- Use {{ now }} macro for timestamp placed in page footer

  This displays the time the website is actually built and deployed
  which can aid in verifying deployments (vs. using Git last mod times)