### PR TITLE
Issue #81 - Add Twitter card meta tags

### DIFF
--- a/archetypes/post.md
+++ b/archetypes/post.md
@@ -9,8 +9,10 @@ description: "{{ replace .Name "-" " " | title }}"
 #author_github: "github-name"
 
 header_image: "/img/keyboard-closeup.jpg"
-# preview image displayed in Slack link
-#preview_image: "/img/..."
+
+# preview image displayed in Slack and Twitter link
+#images:
+#- "/img/..."
 
 # include Table of Contents in side nav
 include_toc: true

--- a/config.toml
+++ b/config.toml
@@ -30,8 +30,8 @@ summaryLength = 40
     header_image = "/img/laptop-python-books.jpg"
 
     # default preview information displayed in Slack and Twitter links
-    preview_image = "/img/pirates-ogp-link-preview.jpg"
-    preview_description = "We are a group of aspiring pythonistas helping each other improve our skills with the Python programming language through free and inexpensive online resources"
+    images = ["/img/pirates-ogp-link-preview.jpg"]
+    description = "We are a group of aspiring pythonistas helping each other improve our skills with the Python programming language through free and inexpensive online resources"
 
     meetup_url = "https://www.meetup.com/Portland-Python-Pirates/"
     slack_group = "pythonpirates"

--- a/content/post/contribute-to-website.md
+++ b/content/post/contribute-to-website.md
@@ -3,7 +3,8 @@ title: "Contribute to this Website"
 date: 2018-11-19
 header_image: "/img/keyboard-closeup.jpg"
 description: "Contribututions to our website are welcome and encouraged from community members!  This page describes how to get started."
-#preview_image: "/img/keyboard-closeup.jpg"
+images:
+- "/img/keyboard-closeup.jpg"
 include_toc: true
 tags: ["website", "hugo"]
 ---

--- a/content/resources.md
+++ b/content/resources.md
@@ -2,10 +2,12 @@
 title: "Useful Resources"
 date: "2018-11-17"
 header_image: "/img/python-bookshelf.jpg"
-preview_image: "/img/python-bookshelf-og-preview.jpg"
+# preview image used with Slack and Twitter links
+images:
+- "/img/python-bookshelf-og-preview.jpg"
 description: "A pirate's bounty of useful Python websites, books, podcasts, and other resources"
 include_toc: true
-tags: ["website", "book", "pythontutor", "podcast"]
+tags: ["resources", "books", "pythontutor", "podcasts"]
 menu: "main"
 pinned: true
 weight: 20

--- a/layouts/partials/header-meta.html
+++ b/layouts/partials/header-meta.html
@@ -1,13 +1,9 @@
-{{ $preview_img := .Page.Params.preview_image | default .Site.Params.preview_image }}
 {{ $preview_description := .Page.Description | default .Site.Params.preview_description }}
-
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <meta property="og:site_name" content="{{ .Site.Title }}" />
-    <meta property="og:title" content="{{ .Page.LinkTitle }}" />
-    <meta property="og:description" content="{{ $preview_description }}" />
-    <meta property="og:url" content="{{ .Page.Permalink }}" />
-    <meta property="og:image" content="{{ $preview_img | absURL }}" />
-    <meta property="og:type" content="website" />
+    {{ template "_internal/opengraph.html" . }}
+
+    {{ template "_internal/twitter_cards.html" . }}


### PR DESCRIPTION
- Updated pages to use built-in Hugo templates for Twitter and Open Graph Protocol
- retained `og:site_name` as that doesn't seem to be rendered
- preview image in links now uses standard 'images' value from content front matter