### PR TITLE
Updated last modified date handling

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -39,6 +39,7 @@ summaryLength = 40
     slack_url = "https://pythonpirates.slack.com"
     slack_join_request_url = "https://join.slack.com/t/pythonpirates/shared_invite/enQtNDYyMjg5NzEyMzM2LTlhNjAxYjJiOTVkYjA2ODE3MDc0ZTQ1YmQ2YWEwODJlZTIwY2Y5YmUzYjNhNDIxMTlhYWJjZGYwNWU5MzVkYmI"
     github_url = "https://github.com/PDXPythonPirates"
+    github_version_url = "https://github.com/PDXPythonPirates/pythonpirates.org/commit/"
     twitter_url = "https://twitter.com/pythonpirates"
     include_toc = false
 
@@ -55,6 +56,12 @@ summaryLength = 40
     # link text displayed in banner box at the top of content section
     urgent_link_title = "Urgent: edX Policy Change"
     urgent_date = "2018-12-13"
+
+[frontmatter]
+    # default order checks Git first
+    #lastmod = [":git", "lastmod", "date", "publishDate"]
+    lastmod = ["lastmod", ":git", "date", "publishDate"]
+
 
 [taxonomies]
     tag = "tags"

--- a/content/_index.md
+++ b/content/_index.md
@@ -1,6 +1,7 @@
 ---
 title: "Portland Python Pirates"
 date: "2018-11-17"
+lastmod: "2018-11-17"
 header_image: "/img/laptop-python-books.jpg"
 menu: "main"
 ---

--- a/content/about.md
+++ b/content/about.md
@@ -1,6 +1,7 @@
 ---
 title: "About Us"
 date: "2018-11-17"
+lastmod: "2018-11-17"
 header_image: "/img/py_meetup_group.jpg"
 menu: "main"
 ---

--- a/content/edx.md
+++ b/content/edx.md
@@ -1,6 +1,7 @@
 ---
 title: "Urgent: edX Policy Change"
 date: "2018-12-13"
+lastmod: "2018-12-13"
 menu: "main"
 tags: ["edx"]
 pinned: true

--- a/content/next-week-goals.md
+++ b/content/next-week-goals.md
@@ -1,6 +1,8 @@
 ---
 title: "Goals for Next Tuesday"
 date: "2019-05-02"
+lastmod: "2019-05-02"
+include_date: true
 header_image: "/img/python-bookshelf.jpg"
 # preview image used with Slack and Twitter links
 images:

--- a/content/post/contribute-to-website.md
+++ b/content/post/contribute-to-website.md
@@ -1,6 +1,7 @@
 ---
 title: "Contribute to this Website"
 date: 2018-11-19
+lastmod: 2018-11-19
 header_image: "/img/keyboard-closeup.jpg"
 description: "Contribututions to our website are welcome and encouraged from community members!  This page describes how to get started."
 images:

--- a/content/post/example-unpublished.md
+++ b/content/post/example-unpublished.md
@@ -1,6 +1,7 @@
 ---
 title: "Making Draft Content Visible"
 date: 2018-11-18
+lastmod: 2019-01-01
 author: ""
 header_image: "/img/keyboard-closeup.jpg"
 draft: true

--- a/content/post/how-to-read-in-file-content.md
+++ b/content/post/how-to-read-in-file-content.md
@@ -2,6 +2,7 @@
 title: "How to Open and Read Files"
 description: "A short tutorial that shows how to open and read text files using Python"
 date: 2018-12-04
+lastmod: 2018-12-04
 #author: "Matt Phillips"
 #author_github: "imattman"
 header_image: "/img/keyboard-closeup.jpg"

--- a/content/post/how-to-set-up-virtual-env.md
+++ b/content/post/how-to-set-up-virtual-env.md
@@ -2,6 +2,7 @@
 title: "How to Set Up a Virtual Environment"
 description: "A short tutorial for configuring a virtual environment in your Python project."
 date: 2019-05-03
+lastmod: 2019-05-03
 #author: "Matt Phillips"
 #author_github: "imattman"
 header_image: "/img/keyboard-closeup.jpg"

--- a/content/resources.md
+++ b/content/resources.md
@@ -1,6 +1,9 @@
 ---
 title: "Useful Resources"
 date: "2018-11-17"
+# if not set, lastmod is determined from Git info
+#lastmod: "2018-11-17"
+include_lastmod: true
 header_image: "/img/python-bookshelf.jpg"
 # preview image used with Slack and Twitter links
 images:

--- a/content/start.md
+++ b/content/start.md
@@ -1,6 +1,7 @@
 ---
 title: "Getting Started"
 date: "2018-11-17"
+lastmod: "2018-11-17"
 header_image: "/img/Portland_Night_panorama.jpg"
 description: "New member onboarding instructions"
 menu: "main"

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,21 +1,28 @@
 {{ define "main" }}
 
+{{ $show_pub_date := or (eq .Type "post") (.Page.Params.include_date) }}
+{{ $page_modifed := (ne (.Date.Format "2006-01-02") (.Lastmod.Format "2006-01-02")) }}
+{{ $show_lastmod := or (.Page.Params.include_lastmod) (and ($show_pub_date) ($page_modifed)) }}
+
 {{ partial "urgent-banner.html" . }}
 
 <div class="columns">
     <div class="column is-9">
         <div class="tile is-child box">
             <div class="content">
-                {{ if eq .Type "post" }}
-                    {{ partial "author-info.html" . }}
+                {{ if $show_pub_date }}
+                  {{ partial "author-info.html" . }}
+                  {{ .Date.Format "January 2, 2006" }}
+                  {{ if $show_lastmod }}
+                    &middot;
+                  {{ end }}
                 {{ end }}
-                {{ .Date.Format "January 2, 2006" }}
-
-                {{ if ne ( .Date.Format "2006-01-02" ) ( .Lastmod.Format "2006-01-02" ) }}
-                  &middot;
-                  Last updated {{ .Lastmod.Format "January 2, 2006" }}
+                {{ if $show_lastmod }}
+                    Last updated {{ .Lastmod.Format "January 2, 2006" }}
                 {{ end }}
-                <hr>
+                {{ if or ($show_pub_date) ($show_lastmod) }}
+                  <hr>
+                {{ end }}
 
                 {{ .Content }}
             </div>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -16,7 +16,13 @@
     </div>
     <div class="content has-text-centered has-text-grey-light is-size-7">
         <p>
-            <em>Site updated {{ now.Format "2006-01-02 3:04 PM MST" }}</em>
+            <em>Site updated {{ now.Format "2006-01-02" }}</em>
+            {{ if .IsPage }}
+            &middot;
+            <em>Page updated  {{ .Page.GitInfo.AuthorDate.Format "2006-01-02" }} - 
+              <a class="has-text-grey-light" href="{{.Site.Params.github_version_url}}{{.Page.GitInfo.Hash}}">{{.Page.GitInfo.AbbreviatedHash}}</a>
+            </em>
+            {{ end }}
         </p>
     </div>
 </footer>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,6 +1,10 @@
 <!DOCTYPE html>
 <html lang="{{ $.Site.LanguageCode | default "en" }}">
 <head>
+    {{ (printf `<!--  Site published:  %s  -->` time.Now) | safeHTML }}
+    {{ if .IsPage -}}
+    {{ (printf `<!--  Page updated:    %s  -->` .GitInfo.AuthorDate) | safeHTML }}
+    {{ end }}
     <title>{{ .Site.Title }} {{ with .Title }} | {{ . }}{{ end }}</title>
     {{- partial "header-meta.html" . -}}
 


### PR DESCRIPTION
- changed Hugo config so `.Page.Lastmod` first reads attribute `lastmod`
  in front matter, falls back to git info
- added `lastmod` attribute to pages (standard Hugo page attribute)
- added support for front matter boolean attributes:
  - `include_date`
  - `include_lastmod`
- added commit of last page update as link in footer
- added  site and page publish info as HTML comment in <head>